### PR TITLE
fix: trim whitespace from IP Address validation (fixes #7)

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -46,7 +46,7 @@ const Schema = z.object({
 	description: z.string().optional(),
 	ipAddress: z.string().min(1, {
 		message: "IP Address is required",
-	}),
+	}).trim(),
 	port: z.number().optional(),
 	username: z.string().optional(),
 	sshKeyId: z.string().min(1, {


### PR DESCRIPTION
**Fixes #7** 

**Description**
When users entered server IP addresses with leading or trailing whitespace (e.g., " 192.168.1.1 "), SSH connections failed because the raw string (including spaces) was passed to the connection logic. This PR fixes that by trimming whitespace before processing the IP input.

**Root Cause**
The form validation schema in `handle-servers.tsx` did not sanitize input values before validation or connection attempts.

**Fix Summary**

- Added .trim() to the IP address field in the Zod schema to remove leading and trailing whitespace.

**Files Modified**

`handle-servers.tsx`

**Verification**

✅ Tested with both trimmed and untrimmed IP addresses.

Before:

https://github.com/user-attachments/assets/daa1c5b8-0f1e-4cd8-83a1-aa81d4adc8ba

After:


https://github.com/user-attachments/assets/56e21904-7de9-4555-a1dd-1195d61d7214


**Impact**
This is a minor input validation fix with no breaking changes. It improves usability and prevents unnecessary SSH connection errors due to whitespace input.
