### PR TITLE
fix: hide plain-text password fields in App Security view (fixes #2)

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
@@ -1,4 +1,5 @@
 import { AlertBlock } from "@/components/shared/alert-block";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -151,7 +152,7 @@ export const HandleSecurity = ({
 									<FormItem>
 										<FormLabel>Password</FormLabel>
 										<FormControl>
-											<Input placeholder="test" {...field} />
+											<ToggleVisibilityInput {...field} />
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
@@ -152,7 +152,7 @@ export const HandleSecurity = ({
 									<FormItem>
 										<FormLabel>Password</FormLabel>
 										<FormControl>
-											<ToggleVisibilityInput {...field} />
+											<ToggleVisibilityInput placeholder="test1" {...field} />
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/handle-security.tsx
@@ -1,5 +1,4 @@
 import { AlertBlock } from "@/components/shared/alert-block";
-import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -152,7 +151,7 @@ export const HandleSecurity = ({
 									<FormItem>
 										<FormLabel>Password</FormLabel>
 										<FormControl>
-											<ToggleVisibilityInput placeholder="test1" {...field} />
+											<Input type="password" placeholder="test1" {...field} />
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
@@ -11,6 +11,9 @@ import { api } from "@/utils/api";
 import { LockKeyhole, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { HandleSecurity } from "./handle-security";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 interface Props {
 	applicationId: string;
@@ -61,16 +64,14 @@ export const ShowSecurity = ({ applicationId }: Props) => {
 									<div className="flex w-full flex-col sm:flex-row justify-between sm:items-center gap-4 sm:gap-10 border rounded-lg p-4">
 										<div className="grid grid-cols-1 sm:grid-cols-2 flex-col gap-4 sm:gap-8">
 											<div className="flex flex-col gap-1">
-												<span className="font-medium">Username</span>
-												<span className="text-sm text-muted-foreground">
-													{security.username}
-												</span>
+												<Label>User</Label>
+												<Input disabled value={security.username} />
 											</div>
 											<div className="flex flex-col gap-1">
-												<span className="font-medium">Password</span>
-												<span className="text-sm text-muted-foreground">
-													{security.password}
-												</span>
+												<Label>Password</Label>
+												<div className="flex flex-row gap-4">
+													<ToggleVisibilityInput disabled value={security.password} />
+												</div>
 											</div>
 										</div>
 										<div className="flex flex-row gap-2">


### PR DESCRIPTION
Fixes #5  — [SECURITY] Password visible in plain text in App Security view

**Description**

In the **App → Advanced → Security** view, the Basic Authentication password was displayed in plain text, creating a potential security issue and an inconsistent user experience across password fields.

This PR ensures that all password fields are hidden by default, consistent with other credential components throughout the codebase.

**Root Cause**

- `handle-security.tsx` used a plain text input for password entry.
- `show-security.tsx` displayed the password directly in a `<span>`.

**Fix Summary**
- `handle-security.tsx`
  - Initially replaced the plain input with `ToggleVisibilityInput`, but it caused unintended form submissions.
  - Final fix: reverted to using a regular `<Input type="password" />`, which hides passwords by default and aligns with other password fields in the app (`register.tsx`).

- `show-security.tsx`
  - Replaced `<span>` with `<Label>` and `<ToggleVisibilityInput disabled value={password}>`, ensuring consistency with the secure display pattern used in `show-internal-mongo-credentials.tsx`.
 
**Reference Implementation**
- Followed the same structure as in `show-internal-mongo-credentials.tsx`, where:
  - Username → `<Label>` + `<Input disabled>`
  - Password → `<Label>` + `<ToggleVisibilityInput disabled>`

**Files Modified**
- `handle-security.tsx`
- `show-security.tsx`

**Verification**

- ✅ Passwords in the edit form are hidden by default.
- ✅ Passwords in display mode are masked and toggleable.
- ✅ Verified consistent UX with other credential components.

https://github.com/user-attachments/assets/258010b7-9fa9-4bc2-8eff-8beb62beee6c



**Impact**
- Prevents accidental exposure of passwords in the Security view.
- Improves consistency and adherence to secure UI patterns.
- No breaking changes introduced.