### PR TITLE
feat(profile): add custom profile picture upload with preview, validation, and persistence

### DIFF
--- a/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
@@ -7,6 +7,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { Dropzone } from "@/components/ui/dropzone";
 import {
 	Form,
 	FormControl,
@@ -22,7 +23,7 @@ import { Switch } from "@/components/ui/switch";
 import { generateSHA256Hash } from "@/lib/utils";
 import { api } from "@/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader2, User } from "lucide-react";
+import { Loader2, Trash, Upload, User } from "lucide-react";
 import { useTranslation } from "next-i18next";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -69,13 +70,43 @@ export const ProfileForm = () => {
 	} = api.user.update.useMutation();
 	const { t } = useTranslation("settings");
 	const [gravatarHash, setGravatarHash] = useState<string | null>(null);
+	const [uploadMode, setUploadMode] = useState<"predefined" | "custom">(
+		"predefined",
+	);
+	const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+	const {
+		mutateAsync: uploadMutation,
+		isLoading: isUploading,
+	} = api.user.uploadProfilePicture.useMutation();
 
 	const availableAvatars = useMemo(() => {
-		if (gravatarHash === null) return randomImages;
-		return randomImages.concat([
-			`https://www.gravatar.com/avatar/${gravatarHash}`,
-		]);
-	}, [gravatarHash]);
+		const avatars =
+			gravatarHash === null
+				? randomImages
+				: randomImages.concat([
+						`https://www.gravatar.com/avatar/${gravatarHash}`,
+					]);
+
+		if (
+			data?.user?.image &&
+			data.user.image.startsWith("/uploads/profiles/")
+		) {
+			return [data.user.image, ...avatars];
+		}
+
+		return avatars;
+	}, [gravatarHash, data?.user?.image]);
+
+	const hasCustomUpload = useMemo(() => {
+		return data?.user?.image?.startsWith("/uploads/profiles/") || false;
+	}, [data?.user?.image]);
+
+	const customImageFilename = useMemo(() => {
+		if (!hasCustomUpload || !data?.user?.image) return null;
+		const parts = data.user.image.split("/");
+		return parts[parts.length - 1]; // Extract filename from path
+	}, [hasCustomUpload, data?.user?.image]);
 
 	const form = useForm<Profile>({
 		defaultValues: {
@@ -111,6 +142,72 @@ export const ProfileForm = () => {
 			}
 		}
 	}, [form, data]);
+
+	useEffect(() => {
+		if (hasCustomUpload) {
+			setUploadMode("custom");
+		}
+	}, [hasCustomUpload]);
+
+	const handleFileUpload = async (file: File) => {
+		setSelectedFile(file);
+
+		const allowedTypes = [
+			"image/jpeg",
+			"image/jpg",
+			"image/png",
+			"image/gif",
+			"image/webp",
+		];
+		const maxSize = 2 * 1024 * 1024; // 2MB
+
+		if (!allowedTypes.includes(file.type)) {
+			toast.error("Please upload a JPG, PNG, GIF, or WEBP image");
+			setSelectedFile(null);
+			return;
+		}
+
+		if (file.size > maxSize) {
+			toast.error("File size must be less than 2MB");
+			setSelectedFile(null);
+			return;
+		}
+
+		const formData = new FormData();
+		formData.append("profilePicture", file);
+
+		await uploadMutation(formData)
+			.then(async (updatedUser) => {
+				toast.success("Profile picture uploaded");
+				form.setValue("image", updatedUser.image || "");
+				setUploadMode("custom");
+				await refetch();
+			})
+			.catch(() => {
+				toast.error("Error uploading profile picture");
+				setSelectedFile(null);
+			});
+	};
+
+	const handleDeleteCustomUpload = async () => {
+		const firstPredefinedAvatar = randomImages[0];
+
+		form.setValue("image", firstPredefinedAvatar);
+
+		await mutateAsync({
+			email: data?.user?.email || "",
+			image: firstPredefinedAvatar,
+		})
+			.then(async () => {
+				await refetch();
+				toast.success("Switched to predefined avatar");
+				setSelectedFile(null);
+				setUploadMode("predefined");
+			})
+			.catch(() => {
+				toast.error("Error updating avatar");
+			});
+	};
 
 	const onSubmit = async (values: Profile) => {
 		await mutateAsync({
@@ -233,12 +330,35 @@ export const ProfileForm = () => {
 														<FormControl>
 															<RadioGroup
 																onValueChange={(e) => {
-																	field.onChange(e);
+																	if (e === "__custom_upload__") {
+																		setUploadMode("custom");
+																	} else {
+																		setUploadMode("predefined");
+																		field.onChange(e);
+																	}
 																}}
 																defaultValue={field.value}
-																value={field.value}
+																value={
+																	uploadMode === "custom"
+																		? "__custom_upload__"
+																		: field.value
+																}
 																className="flex flex-row flex-wrap gap-2 max-xl:justify-center"
 															>
+																<FormItem>
+																	<FormLabel className="[&:has([data-state=checked])>div]:border-primary [&:has([data-state=checked])>div]:border-2 cursor-pointer">
+																		<FormControl>
+																			<RadioGroupItem
+																				value="__custom_upload__"
+																				className="sr-only"
+																			/>
+																		</FormControl>
+																		<div className="h-12 w-12 rounded-full border-2 border-dashed flex items-center justify-center hover:border-primary transition-all bg-background">
+																			<Upload className="h-5 w-5 text-muted-foreground" />
+																		</div>
+																	</FormLabel>
+																</FormItem>
+
 																{availableAvatars.map((image) => (
 																	<FormItem key={image}>
 																		<FormLabel className="[&:has([data-state=checked])>img]:border-primary [&:has([data-state=checked])>img]:border-1 [&:has([data-state=checked])>img]:p-px cursor-pointer">
@@ -260,6 +380,75 @@ export const ProfileForm = () => {
 																))}
 															</RadioGroup>
 														</FormControl>
+														<FormDescription>
+															{uploadMode === "custom"
+																? "Max 2MB • JPG, PNG, GIF, WEBP"
+																: "Choose a predefined avatar or upload your own custom image"}
+														</FormDescription>
+
+														{uploadMode === "custom" && (
+															<div className="mt-4 space-y-4">
+																{(selectedFile || hasCustomUpload) && !isUploading && (
+																	<div className="flex flex-row gap-4 items-center justify-between p-4 border rounded-lg">
+																		<div className="flex flex-row gap-4 items-center">
+																			<img
+																				src={
+																					selectedFile
+																						? URL.createObjectURL(selectedFile)
+																						: data?.user?.image || ""
+																				}
+																				alt="Preview"
+																				className="h-12 w-12 rounded-full object-cover"
+																			/>
+																			<div>
+																				<p className="text-sm font-medium">
+																					{selectedFile
+																						? selectedFile.name
+																						: customImageFilename || "Custom Image"}
+																				</p>
+																				<p className="text-sm text-muted-foreground">
+																					{selectedFile
+																						? `${(selectedFile.size / 1024).toFixed(1)} KB`
+																						: "Uploaded"}
+																				</p>
+																			</div>
+																		</div>
+																		<Button
+																			type="button"
+																			variant="ghost"
+																			size="sm"
+																			onClick={handleDeleteCustomUpload}
+																			disabled={isUploading || isUpdating}
+																		>
+																			<Trash className="w-4 h-4 text-muted-foreground" />
+																		</Button>
+																	</div>
+																)}
+
+																{!selectedFile && !hasCustomUpload && !isUploading && (
+																	<Dropzone
+																		dropMessage="Drop image or click here"
+																		accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
+																		onChange={(files) => {
+																			if (
+																				files instanceof FileList &&
+																				files[0]
+																			) {
+																				handleFileUpload(files[0]);
+																			}
+																		}}
+																	/>
+																)}
+
+																{isUploading && (
+																	<p className="text-sm text-muted-foreground flex items-center gap-2">
+																		<Loader2 className="h-4 w-4 animate-spin" />
+																		Uploading...
+																	</p>
+																)}
+															</div>
+														)}
+
 														<FormMessage />
 													</FormItem>
 												)}

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -44,9 +44,15 @@ export const UserNav = () => {
 					<Avatar className="h-8 w-8 rounded-lg">
 						<AvatarImage
 							src={data?.user?.image || ""}
-							alt={data?.user?.image || ""}
+							alt={data?.user?.name || data?.user?.email || "Avatar"}
 						/>
-						<AvatarFallback className="rounded-lg">CN</AvatarFallback>
+						<AvatarFallback className="rounded-lg">
+							{data?.user?.name
+								? data.user.name.slice(0, 2).toUpperCase()
+								: data?.user?.email
+									? data.user.email.slice(0, 2).toUpperCase()
+									: "CN"}
+						</AvatarFallback>
 					</Avatar>
 					<div className="grid flex-1 text-left text-sm leading-tight">
 						<span className="truncate font-semibold">Account</span>

--- a/apps/dokploy/public/uploads/profiles/.gitkeep
+++ b/apps/dokploy/public/uploads/profiles/.gitkeep
@@ -1,0 +1,2 @@
+# This directory stores user-uploaded profile pictures
+# Format: {userId}/{userId}-{timestamp}.{ext}

--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -19,16 +19,22 @@ import {
 	apikey,
 	invitation,
 	member,
+	users_temp,
 } from "@dokploy/server/db/schema";
+import { cleanupOldProfilePictures } from "@dokploy/server/utils/user/cleanup-profile-pictures";
 import { TRPCError } from "@trpc/server";
 import * as bcrypt from "bcrypt";
 import { and, asc, eq, gt } from "drizzle-orm";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { z } from "zod";
+import { uploadProfilePictureSchema } from "@/utils/schema";
 import {
 	adminProcedure,
 	createTRPCRouter,
 	protectedProcedure,
 	publicProcedure,
+	uploadProcedure,
 } from "../trpc";
 
 const apiCreateApiKey = z.object({
@@ -419,5 +425,98 @@ export const userRouter = createTRPCRouter({
 				throw error;
 			}
 			return inviteLink;
+		}),
+
+	uploadProfilePicture: protectedProcedure
+		.use(uploadProcedure)
+		.input(uploadProfilePictureSchema)
+		.mutation(async ({ input, ctx }) => {
+			const profilePicture = input.profilePicture;
+			const userId = ctx.user.id;
+
+			const allowedMimeTypes = [
+				"image/jpeg",
+				"image/jpg",
+				"image/png",
+				"image/gif",
+				"image/webp",
+			];
+			const allowedExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
+
+			if (!allowedMimeTypes.includes(profilePicture.type)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Invalid file type. Allowed types: ${allowedExtensions.join(", ")}`,
+				});
+			}
+
+			const maxSize = 2 * 1024 * 1024; // 2MB in bytes
+			if (profilePicture.size > maxSize) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "File size exceeds 2MB limit",
+				});
+			}
+
+			const extension = path.extname(profilePicture.name).toLowerCase();
+			if (!allowedExtensions.includes(extension)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Invalid file extension. Allowed: ${allowedExtensions.join(", ")}`,
+				});
+			}
+
+			try {
+				const timestamp = Date.now();
+				const filename = `${userId}-${timestamp}${extension}`;
+
+				const publicPath = path.join(process.cwd(), "public");
+				const userProfileDir = path.join(
+					publicPath,
+					"uploads/profiles",
+					userId,
+				);
+				await fs.mkdir(userProfileDir, { recursive: true });
+
+				const arrayBuffer = await profilePicture.arrayBuffer();
+				const buffer = Buffer.from(arrayBuffer);
+
+				const filePath = path.join(userProfileDir, filename);
+				await fs.writeFile(filePath, buffer);
+
+				const fileExists = await fs
+					.access(filePath)
+					.then(() => true)
+					.catch(() => false);
+
+				if (!fileExists) {
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message: "Failed to save file to disk",
+					});
+				}
+
+				await cleanupOldProfilePictures(userId, filename);
+
+				const imagePath = `/uploads/profiles/${userId}/${filename}`;
+				await db
+					.update(users_temp)
+					.set({
+						image: imagePath,
+					})
+					.where(eq(users_temp.id, userId));
+
+				const updatedUser = await findUserById(userId);
+				return updatedUser;
+			} catch (error) {
+				console.error("Error uploading profile picture:", error);
+				if (error instanceof TRPCError) {
+					throw error;
+				}
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to upload profile picture",
+				});
+			}
 		}),
 });

--- a/apps/dokploy/utils/schema.ts
+++ b/apps/dokploy/utils/schema.ts
@@ -17,3 +17,11 @@ export const uploadFileSchema = zfd.formData({
 });
 
 export type UploadFile = z.infer<typeof uploadFileSchema>;
+
+export const uploadProfilePictureSchema = zfd.formData({
+	profilePicture: zfd.file(),
+});
+
+export type UploadProfilePicture = z.infer<
+	typeof uploadProfilePictureSchema
+>;

--- a/packages/server/src/utils/user/cleanup-profile-pictures.ts
+++ b/packages/server/src/utils/user/cleanup-profile-pictures.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+
+export const deleteProfilePicture = async (
+	filePath: string,
+): Promise<void> => {
+	try {
+		await fs.unlink(filePath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+	}
+};
+
+
+export const cleanupOldProfilePictures = async (
+	userId: string,
+	currentFileName?: string,
+): Promise<void> => {
+	const publicPath = path.join(process.cwd(), "public");
+	const userProfileDir = path.join(publicPath, "uploads/profiles", userId);
+
+	try {
+		const files = await fs.readdir(userProfileDir);
+
+		for (const file of files) {
+			if (currentFileName && file === currentFileName) {
+				continue;
+			}
+
+			if (file.startsWith(`${userId}-`)) {
+				const filePath = path.join(userProfileDir, file);
+				await deleteProfilePicture(filePath);
+			}
+		}
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+	}
+};


### PR DESCRIPTION
Closes #12 
## Motivation

Users could only pick from predefined avatars. This adds the ability to upload a custom profile picture, bringing the profile experience in line with modern UX expectations.

### What's Included

- ### Backend

    - `uploadProfilePicture` TRPC mutation with MIME+extension validation and 2MB limit.

    - Stores files under `public/uploads/profiles/{userId}/{userId}-{timestamp}.{ext}`.

    - Updates `users_temp.image` and **cleans up old files** on next upload.

    - Fix for path duplication by correctly joining `process.cwd()` with `public`.

- ### Frontend

    - Profile form now includes an "Upload Custom" option alongside predefined avatars.

    - Integrated Dropzone (click/drag-and-drop), client-side validation, **live preview,** error toasts.

    - Auto-detects existing custom upload and shows preview on refresh.

    - Switch back to predefined avatars anytime.

    - **Navbar avatar fallback** now uses dynamic initials (no more hardcoded "CN").

### Tech Notes
    - Table used: `users_temp` (`image` text field).

    - Allowed types: **JPG, JPEG, PNG, GIF, WEBP**; max size **2MB**.

    - New utility: `cleanup-profile-pictures.ts` deletes older images for the user.

    - Directory scaffold tracked via `.gitkeep`.

### How to Test

1. Go to Settings → Profile.

2. Choose Upload Custom.

3. Pick a small image (< 2MB). Confirm preview appears.

4. Save profile. Refresh the page—custom image should persist.

5. Switch to a predefined avatar—preview updates immediately.

6. Upload a new custom image—old file should be removed server-side.

### Security

- Blocks non-image uploads (MIME + extension).

- User-scoped directories; sanitized filename; no SVGs.

- Protected resolver (auth required).

### Deployment Checklist

- Ensure `public/uploads/profiles/` exists and is writable (dirs `755`, files `644`).

- Monitor disk usage post-deploy.

### Videos 

1. UI demo (upload + preview + switch).

https://github.com/user-attachments/assets/1caed85b-c44f-4c71-809a-c902d003458a

2. Backend code changes (schema, route, cleanup utility).

https://github.com/user-attachments/assets/3177a414-e114-4927-b374-3bf3a7b512cc

3. Frontend code changes (profile form integration, user-nav initials).

https://github.com/user-attachments/assets/3564fa6e-b7ca-48ce-9a47-37e1b257228c