### PR TITLE
feat: Add Cmd/Ctrl+K keyboard shortcut to focus search inputs (#27)

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -1,3 +1,4 @@
+import { useSearchShortcut } from "@/hooks/use-search-shortcut";
 import { BreadcrumbSidebar } from "@/components/shared/breadcrumb-sidebar";
 import { DateTooltip } from "@/components/shared/date-tooltip";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
@@ -49,6 +50,7 @@ import { HandleProject } from "./handle-project";
 import { ProjectEnvironment } from "./project-environment";
 
 export const ShowProjects = () => {
+	const searchInputRef = useSearchShortcut();
 	const utils = api.useUtils();
 	const { data, isLoading } = api.project.all.useQuery();
 	const { data: auth } = api.user.get.useQuery();
@@ -100,6 +102,7 @@ export const ShowProjects = () => {
 								<>
 									<div className="w-full relative">
 										<Input
+											ref={searchInputRef}
 											placeholder="Filter projects..."
 											value={searchQuery}
 											onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/dokploy/hooks/use-search-shortcut.tsx
+++ b/apps/dokploy/hooks/use-search-shortcut.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+
+export const useSearchShortcut = () => {
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+			const isShortcut = isMac
+				? event.metaKey && event.key === "k"
+				: event.ctrlKey && event.key === "k";
+
+			if (!isShortcut) return;
+
+			const activeElement = document.activeElement;
+			const isInputFocused =
+				activeElement instanceof HTMLInputElement ||
+				activeElement instanceof HTMLTextAreaElement ||
+				activeElement instanceof HTMLSelectElement ||
+				activeElement?.getAttribute("contenteditable") === "true";
+
+			if (isInputFocused) return;
+
+			event.preventDefault();
+
+			searchInputRef.current?.focus();
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, []);
+
+	return searchInputRef;
+};

--- a/apps/dokploy/pages/dashboard/project/[projectId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId].tsx
@@ -1,3 +1,4 @@
+import { useSearchShortcut } from "@/hooks/use-search-shortcut";
 import { AddApplication } from "@/components/dashboard/project/add-application";
 import { AddCompose } from "@/components/dashboard/project/add-compose";
 import { AddDatabase } from "@/components/dashboard/project/add-database";
@@ -219,6 +220,7 @@ export const extractServices = (data: Project | undefined) => {
 const Project = (
 	props: InferGetServerSidePropsType<typeof getServerSideProps>,
 ) => {
+	const searchInputRef = useSearchShortcut();
 	const [isBulkActionLoading, setIsBulkActionLoading] = useState(false);
 	const { projectId } = props;
 	const { data: auth } = api.user.get.useQuery();
@@ -846,6 +848,7 @@ const Project = (
 										<div className="flex flex-col gap-2 lg:flex-row lg:gap-4 lg:items-center">
 											<div className="w-full relative">
 												<Input
+													ref={searchInputRef}
 													placeholder="Filter services..."
 													value={searchQuery}
 													onChange={(e) => setSearchQuery(e.target.value)}


### PR DESCRIPTION
## 🎯 Summary

Implements keyboard shortcuts (Cmd+K on Mac, Ctrl+K on Windows/Linux) to focus search/filter inputs throughout the Dokploy application. This enhancement improves accessibility and enables keyboard-driven workflows for users who prefer not to use a mouse.

Closes #27

---

## 🛠️ Changes Made

### New Files
- **`apps/dokploy/hooks/use-search-shortcut.tsx`**: Reusable React hook for keyboard shortcut management

### Modified Files
- **`apps/dokploy/components/dashboard/projects/show.tsx`**: Added keyboard shortcut to Projects filter
- **`apps/dokploy/pages/dashboard/project/[projectId].tsx`**: Added keyboard shortcut to Services filter

---

## 🧪 Testing

### Manual Testing Checklist

#### Projects Page (`/dashboard/projects`)
- [x] Press Cmd+K (Mac) or Ctrl+K (Windows/Linux)
- [x] Verify "Filter projects..." input receives focus
- [x] Verify you can immediately start typing
- [x] Click into any other input field on the page
- [x] While focused in that input, press Cmd/Ctrl+K
- [x] Verify shortcut does NOT trigger (focus stays in current input)
- [x] Click outside all inputs, press Cmd/Ctrl+K again
- [x] Verify search input receives focus

#### Services Page (`/dashboard/project/[projectId]`)
- [x] Press Cmd+K (Mac) or Ctrl+K (Windows/Linux)
- [x] Verify "Filter services..." input receives focus
- [x] Verify you can immediately start typing
- [x] Test the same conflict-avoidance scenarios as above

#### Edge Cases
- [x] Shortcut works when no other element has focus
- [x] Shortcut doesn't interfere with textareas
- [x] Shortcut doesn't interfere with contenteditable elements
- [x] Shortcut doesn't interfere with select dropdowns

---

## 🚀 Future Enhancements

While this PR focuses on search input shortcuts, the foundation is laid for:
- Full command palette (Cmd+K could trigger a modal with multiple actions)
- Additional keyboard shortcuts for common actions
- Keyboard shortcut help modal

---


https://github.com/user-attachments/assets/fbbed68c-6c3c-45af-9916-573e017b3812


---
## ✅ Acceptance Criteria

All acceptance criteria from #27 have been met:
- ✅ Cmd+K (Mac) / Ctrl+K (Windows/Linux) focuses search on Projects page
- ✅ Cmd+K (Mac) / Ctrl+K (Windows/Linux) focuses search on Services page
- ✅ Shortcut doesn't trigger when user is focused in another input
- ✅ Browser default is prevented
- ✅ Implementation is reusable across pages